### PR TITLE
fix: register file-open listener and clean up resources in onunload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -59,27 +59,29 @@ export default class RhoReader extends Plugin {
 			(leaf) => new RhoReaderPane(leaf, this)
 		);
 
-		this.app.workspace.on("file-open", async (file: TFile | null) => {
-			let feedUrl: string | null = null;
-			if (file) {
-				const fileCache = this.app.metadataCache.getFileCache(file);
-				if (fileCache?.frontmatter?.rho_feed_url) {
-					// Post file opened (e.g. via "Take notes") — keep current feed displayed
-					return;
+		this.registerEvent(
+			this.app.workspace.on("file-open", async (file: TFile | null) => {
+				let feedUrl: string | null = null;
+				if (file) {
+					const fileCache = this.app.metadataCache.getFileCache(file);
+					if (fileCache?.frontmatter?.rho_feed_url) {
+						// Post file opened (e.g. via "Take notes") — keep current feed displayed
+						return;
+					}
+					feedUrl = fileCache?.frontmatter?.feed_url || null;
 				}
-				feedUrl = fileCache?.frontmatter?.feed_url || null;
-			}
-			let leaf =
-				this.app.workspace.getLeavesOfType(VIEW_TYPE_RHO_READER)[0];
-			if (!leaf) {
-				const rightLeaf = this.app.workspace.getRightLeaf(false);
-				if (!rightLeaf) return;
-				await rightLeaf.setViewState({ type: VIEW_TYPE_RHO_READER });
-				leaf = rightLeaf;
-			}
-			const view = leaf.view as RhoReaderPane;
-			view.setFeedUrl(feedUrl);
-		});
+				let leaf =
+					this.app.workspace.getLeavesOfType(VIEW_TYPE_RHO_READER)[0];
+				if (!leaf) {
+					const rightLeaf = this.app.workspace.getRightLeaf(false);
+					if (!rightLeaf) return;
+					await rightLeaf.setViewState({ type: VIEW_TYPE_RHO_READER });
+					leaf = rightLeaf;
+				}
+				const view = leaf.view as RhoReaderPane;
+				view.setFeedUrl(feedUrl);
+			})
+		);
 
 		this.addSettingTab(new RhoReaderSettingTab(this.app, this));
 
@@ -103,7 +105,15 @@ export default class RhoReader extends Plugin {
 		}
 	}
 
-	onunload() {}
+	onunload() {
+		if (this.saveSettingsTimeout !== null) {
+			window.clearTimeout(this.saveSettingsTimeout);
+			this.saveSettingsTimeout = null;
+			this.saveSettings();
+		}
+		this.app.workspace.detachLeavesOfType(VIEW_TYPE_RHO_READER);
+		this.statusBarItem = null;
+	}
 
 	async loadSettings() {
 		this.settings = Object.assign(


### PR DESCRIPTION
## Summary

- Wrap the `workspace.on("file-open", ...)` subscription in `this.registerEvent(...)` so Obsidian tears it down on plugin unload. Previously, the listener stayed wired to the destroyed plugin across reloads, causing `view.setFeedUrl(...)` to fire against a dead view (flagged by `AGENTS.md`).
- Implement `onunload` cleanup that was previously empty:
  - Flush the pending `saveSettingsTimeout` so the last debounced settings write is not lost
  - Detach `RhoReaderPane` leaves via `workspace.detachLeavesOfType(VIEW_TYPE_RHO_READER)`
  - Clear the `statusBarItem` reference

## Test plan

- [x] `npx tsc -noEmit -skipLibCheck` passes
- [x] `npm test` passes (99/99)
- [ ] Manual: reload the plugin in Obsidian and confirm the file-open handler only runs once per event (no duplicated `setFeedUrl` calls)
- [ ] Manual: change a setting, immediately disable the plugin, re-enable, and confirm the latest setting persisted
- [ ] Manual: open the Rho Reader pane, disable the plugin, and confirm the pane leaf is detached

https://claude.ai/code/session_0185i5c8XiicAc6uc6xP4YbH