### PR TITLE
refactor: stop casting app to any for opening Feed Reader

### DIFF
--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -3,6 +3,7 @@ import type RhoReader from "../main";
 import type { FeedPost } from "../types";
 import { syncAllRssFeeds } from "../commands/syncAllRssFeeds";
 import { importOpml } from "../commands/importOpml";
+import { openRssFeedReader } from "../commands/openRssFeedReader";
 import { updateFeedFrontmatter, findFileForFeedUrl, getPostsForFeed, findExistingPostFile, getPostKey, setPostTags, getAllTagsForFeed, setFeedSyncStatus } from "../commands/utils";
 
 export const VIEW_TYPE_RHO_READER = "rho-reader-pane";
@@ -395,9 +396,7 @@ export class RhoReaderPane extends ItemView {
 		setIcon(rssFeedReaderBtn.createSpan(), "rss");
 		rssFeedReaderBtn.createSpan({ text: "Feed Reader" });
 		rssFeedReaderBtn.addEventListener("click", () => {
-			(this.plugin.app as any).commands.executeCommandById(
-				"rho-reader:open-rss-feed-reader"
-			);
+			openRssFeedReader(this.plugin);
 		});
 
 		const syncBtn = actions.createEl("button", {


### PR DESCRIPTION
## Summary
- Replaces `(this.plugin.app as any).commands.executeCommandById("rho-reader:open-rss-feed-reader")` on the landing page Feed Reader button with a direct call to the `openRssFeedReader` command handler.
- Adds the matching import alongside the existing `importOpml` / `syncAllRssFeeds` imports, so the button follows the same pattern used by the Import OPML and Sync Feeds buttons on the same landing view.
- Removes a `any` type hole without changing any user-visible behaviour.

## Test plan
- [x] `npx tsc -noEmit -skipLibCheck` passes
- [x] `npm test` — all 99 tests pass across 11 files
