### PR TITLE
fix: run readState migration once in onload instead of on every sync

### DIFF
--- a/src/commands/utils/postFiles.test.ts
+++ b/src/commands/utils/postFiles.test.ts
@@ -30,7 +30,6 @@ function createMockPlugin(options: {
 			postsFolder: "Posts",
 			rssFeedBaseFile: "Reader.base",
 			readStateMigrated: false,
-			readState: {},
 			...(options.settings ?? {}),
 		},
 		app: {

--- a/src/commands/utils/updateFeedFrontmatter.ts
+++ b/src/commands/utils/updateFeedFrontmatter.ts
@@ -4,8 +4,6 @@ import { parseRssFeedItems } from "./parseRssFeedItems";
 import {
 	createPostFilesForFeed,
 	updateFeedCountsFromFiles,
-	findExistingPostFile,
-	setPostReadState,
 } from "./postFiles";
 
 export async function updateFeedFrontmatter(
@@ -24,31 +22,6 @@ export async function updateFeedFrontmatter(
 	// Create post files for new posts
 	const feedTitle = file.basename;
 	await createPostFilesForFeed(plugin, feedUrl, feedTitle, posts);
-
-	// Migrate existing readState entries for this feed
-	if (
-		!plugin.settings.readStateMigrated &&
-		plugin.settings.readState?.[feedUrl]
-	) {
-		const readStateForFeed = plugin.settings.readState[feedUrl];
-		for (const [postKey, state] of Object.entries(readStateForFeed)) {
-			if (!state.read) continue;
-			const postFile = findExistingPostFile(plugin, feedUrl, postKey);
-			if (postFile) {
-				await setPostReadState(
-					plugin,
-					postFile,
-					true,
-					state.readAt
-				);
-			}
-		}
-		delete plugin.settings.readState[feedUrl];
-		if (Object.keys(plugin.settings.readState).length === 0) {
-			plugin.settings.readStateMigrated = true;
-		}
-		await plugin.saveSettings();
-	}
 
 	// Update feed file frontmatter with counts read from disk
 	// (avoids stale metadata cache after creating new post files)

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,7 +91,39 @@ export default class RhoReader extends Plugin {
 		this.updateStatusBar();
 
 		registerCommands(this);
-		this.clearStaleSyncStatuses();
+		this.app.workspace.onLayoutReady(() => {
+			this.migrateReadState();
+			this.clearStaleSyncStatuses();
+		});
+	}
+
+	private async migrateReadState(): Promise<void> {
+		if (this.settings.readStateMigrated) return;
+
+		// Legacy shape of data.json prior to file-based post storage.
+		type LegacyPostReadState = { read: boolean; readAt?: number };
+		type LegacyReadState = Record<
+			string,
+			Record<string, LegacyPostReadState>
+		>;
+		const legacy = this.settings as { readState?: LegacyReadState };
+		const readState = legacy.readState;
+
+		if (readState) {
+			for (const [feedUrl, readStateForFeed] of Object.entries(readState)) {
+				for (const [postKey, state] of Object.entries(readStateForFeed)) {
+					if (!state.read) continue;
+					const postFile = findExistingPostFile(this, feedUrl, postKey);
+					if (postFile) {
+						await setPostReadState(this, postFile, true, state.readAt);
+					}
+				}
+			}
+		}
+
+		this.settings.readStateMigrated = true;
+		delete legacy.readState;
+		await this.saveSettings();
 	}
 
 	private async clearStaleSyncStatuses(): Promise<void> {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,23 +1,10 @@
-export interface PostReadState {
-	read: boolean;
-	readAt?: number;
-}
-
-export interface ReadStateByFeed {
-	[postKey: string]: PostReadState;
-}
-
 export interface RhoReaderSettings {
 	rhoFolder: string;
 	rssFeedBaseFile: string;
 	postsFolder: string;
 	syncConcurrency: number;
-	/** @deprecated Used only during migration to file-based post storage */
+	/** @deprecated Flag retained so the one-shot migration in onload runs at most once */
 	readStateMigrated: boolean;
-	/** @deprecated Read state is now stored in post file frontmatter */
-	readState: {
-		[feedUrl: string]: ReadStateByFeed;
-	};
 }
 
 export const DEFAULT_SETTINGS: RhoReaderSettings = {
@@ -26,7 +13,6 @@ export const DEFAULT_SETTINGS: RhoReaderSettings = {
 	postsFolder: "Posts",
 	syncConcurrency: 5,
 	readStateMigrated: false,
-	readState: {},
 };
 
 export const defaultBaseContent = `


### PR DESCRIPTION
## Summary

The lazy migration in `src/commands/utils/updateFeedFrontmatter.ts` re-executed on every sync of every feed. `readStateMigrated` only flipped to `true` when `readState` became fully empty, so any stale feed entry (e.g. a feed that was never resynced, or a feed that was removed) kept the flag `false` and caused the migration block to keep running forever.

Moved the migration into `main.ts` behind `workspace.onLayoutReady` so it runs once against the full `readState` blob (after the metadata cache is ready), unconditionally sets `readStateMigrated = true`, deletes the legacy `readState` field from `data.json`, and persists. Also dropped the deprecated `readState` / `PostReadState` / `ReadStateByFeed` shapes from `RhoReaderSettings`.

## Changes

- `src/main.ts`: new `migrateReadState()` scheduled from `onLayoutReady`; uses inline legacy types to read the now-removed field.
- `src/commands/utils/updateFeedFrontmatter.ts`: deleted the per-sync migration block and its imports.
- `src/settings/settings.ts`: dropped `readState` from `RhoReaderSettings` and `DEFAULT_SETTINGS`; kept `readStateMigrated` as the one-shot gate.
- `src/commands/utils/postFiles.test.ts`: removed the stale `readState: {}` field from the mock settings.

## Test plan

- [x] `npm run build` (tsc + esbuild) passes
- [x] `npm test` — 99/99 tests pass
- [ ] Manual: load a vault that has legacy `readState` in `data.json`, confirm read state is carried over to post files on first load and that `data.json` no longer contains `readState` afterward
- [ ] Manual: load a vault that has `readStateMigrated: true` already; confirm no-op