### PR TITLE
fix: bound and normalize user-supplied settings values

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,10 @@ import {
 	DEFAULT_SETTINGS,
 } from "./settings/settings";
 import {
+	clampSyncConcurrency,
+	normalizeFolderPath,
+} from "./settings/validation";
+import {
 	VIEW_TYPE_RHO_READER,
 	RhoReaderPane,
 } from "./views/RhoReaderPane";
@@ -120,6 +124,14 @@ export default class RhoReader extends Plugin {
 			{},
 			DEFAULT_SETTINGS,
 			await this.loadData()
+		);
+		this.settings.rhoFolder = normalizeFolderPath(
+			this.settings.rhoFolder,
+			DEFAULT_SETTINGS.rhoFolder
+		);
+		this.settings.syncConcurrency = clampSyncConcurrency(
+			this.settings.syncConcurrency,
+			DEFAULT_SETTINGS.syncConcurrency
 		);
 	}
 

--- a/src/settings/RhoReaderSettingTab.ts
+++ b/src/settings/RhoReaderSettingTab.ts
@@ -1,5 +1,12 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import type RhoReader from "../main";
+import { DEFAULT_SETTINGS } from "./settings";
+import {
+	MAX_SYNC_CONCURRENCY,
+	MIN_SYNC_CONCURRENCY,
+	clampSyncConcurrency,
+	normalizeFolderPath,
+} from "./validation";
 
 export class RhoReaderSettingTab extends PluginSettingTab {
 	plugin: RhoReader;
@@ -17,14 +24,27 @@ export class RhoReaderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Rho folder")
 			.setDesc("Folder where Rho Reader stores all its data.")
-			.addText((text) =>
+			.addText((text) => {
 				text
 					.setValue(this.plugin.settings.rhoFolder)
 					.onChange(async (value) => {
 						this.plugin.settings.rhoFolder = value;
 						await this.plugin.saveSettings();
-					})
-			);
+					});
+				text.inputEl.addEventListener("blur", async () => {
+					const normalized = normalizeFolderPath(
+						text.getValue(),
+						DEFAULT_SETTINGS.rhoFolder
+					);
+					if (normalized !== this.plugin.settings.rhoFolder) {
+						this.plugin.settings.rhoFolder = normalized;
+						await this.plugin.saveSettings();
+					}
+					if (normalized !== text.getValue()) {
+						text.setValue(normalized);
+					}
+				});
+			});
 
 		new Setting(containerEl)
 			.setName("RSS Feed Bases")
@@ -40,17 +60,39 @@ export class RhoReaderSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Sync concurrency")
-			.setDesc("Number of feeds to sync in parallel.")
-			.addText((text) =>
+			.setDesc(
+				`Number of feeds to sync in parallel (${MIN_SYNC_CONCURRENCY}–${MAX_SYNC_CONCURRENCY}).`
+			)
+			.addText((text) => {
+				text.inputEl.type = "number";
+				text.inputEl.min = String(MIN_SYNC_CONCURRENCY);
+				text.inputEl.max = String(MAX_SYNC_CONCURRENCY);
 				text
 					.setValue(String(this.plugin.settings.syncConcurrency))
 					.onChange(async (value) => {
-						const num = parseInt(value, 10);
-						if (!isNaN(num) && num >= 1) {
-							this.plugin.settings.syncConcurrency = num;
-							await this.plugin.saveSettings();
-						}
-					})
-			);
+						// Allow the box to be empty while the user is editing;
+						// commit the clamped value on blur.
+						if (value.trim() === "") return;
+						const clamped = clampSyncConcurrency(
+							value,
+							this.plugin.settings.syncConcurrency
+						);
+						this.plugin.settings.syncConcurrency = clamped;
+						await this.plugin.saveSettings();
+					});
+				text.inputEl.addEventListener("blur", async () => {
+					const clamped = clampSyncConcurrency(
+						text.getValue(),
+						DEFAULT_SETTINGS.syncConcurrency
+					);
+					if (clamped !== this.plugin.settings.syncConcurrency) {
+						this.plugin.settings.syncConcurrency = clamped;
+						await this.plugin.saveSettings();
+					}
+					if (String(clamped) !== text.getValue()) {
+						text.setValue(String(clamped));
+					}
+				});
+			});
 	}
 }

--- a/src/settings/validation.test.ts
+++ b/src/settings/validation.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+	MAX_SYNC_CONCURRENCY,
+	MIN_SYNC_CONCURRENCY,
+	clampSyncConcurrency,
+	normalizeFolderPath,
+} from "./validation";
+
+describe("clampSyncConcurrency", () => {
+	it("returns valid integers unchanged", () => {
+		expect(clampSyncConcurrency(5, 1)).toBe(5);
+		expect(clampSyncConcurrency("3", 1)).toBe(3);
+	});
+
+	it("clamps values below the minimum", () => {
+		expect(clampSyncConcurrency(0, 1)).toBe(MIN_SYNC_CONCURRENCY);
+		expect(clampSyncConcurrency(-10, 1)).toBe(MIN_SYNC_CONCURRENCY);
+	});
+
+	it("clamps values above the maximum", () => {
+		expect(clampSyncConcurrency(999, 1)).toBe(MAX_SYNC_CONCURRENCY);
+		expect(clampSyncConcurrency(MAX_SYNC_CONCURRENCY + 1, 1)).toBe(
+			MAX_SYNC_CONCURRENCY
+		);
+	});
+
+	it("floors fractional inputs", () => {
+		expect(clampSyncConcurrency(3.9, 1)).toBe(3);
+		expect(clampSyncConcurrency("7.4", 1)).toBe(7);
+	});
+
+	it("returns fallback when input is empty", () => {
+		expect(clampSyncConcurrency("", 4)).toBe(4);
+		expect(clampSyncConcurrency("   ", 4)).toBe(4);
+	});
+
+	it("returns fallback when input is non-numeric", () => {
+		expect(clampSyncConcurrency("abc", 4)).toBe(4);
+		expect(clampSyncConcurrency(Number.NaN, 4)).toBe(4);
+	});
+
+	it("handles non-finite numbers with fallback", () => {
+		expect(clampSyncConcurrency(Number.POSITIVE_INFINITY, 4)).toBe(4);
+		expect(clampSyncConcurrency(Number.NEGATIVE_INFINITY, 4)).toBe(4);
+	});
+});
+
+describe("normalizeFolderPath", () => {
+	it("returns valid paths unchanged", () => {
+		expect(normalizeFolderPath("Rho", "Fallback")).toBe("Rho");
+		expect(normalizeFolderPath("Rho/Sub", "Fallback")).toBe("Rho/Sub");
+	});
+
+	it("strips leading slashes", () => {
+		expect(normalizeFolderPath("/Rho", "Fallback")).toBe("Rho");
+		expect(normalizeFolderPath("///Rho/Sub", "Fallback")).toBe("Rho/Sub");
+	});
+
+	it("strips trailing slashes", () => {
+		expect(normalizeFolderPath("Rho/", "Fallback")).toBe("Rho");
+		expect(normalizeFolderPath("Rho/Sub//", "Fallback")).toBe("Rho/Sub");
+	});
+
+	it("collapses duplicate separators", () => {
+		expect(normalizeFolderPath("Rho//Sub", "Fallback")).toBe("Rho/Sub");
+	});
+
+	it("converts backslashes to forward slashes", () => {
+		expect(normalizeFolderPath("Rho\\Sub", "Fallback")).toBe("Rho/Sub");
+	});
+
+	it("filters out '..' segments to prevent escaping the vault", () => {
+		expect(normalizeFolderPath("../Rho", "Fallback")).toBe("Rho");
+		expect(normalizeFolderPath("Rho/../../Other", "Fallback")).toBe(
+			"Rho/Other"
+		);
+		expect(normalizeFolderPath("..", "Fallback")).toBe("Fallback");
+	});
+
+	it("filters out '.' segments", () => {
+		expect(normalizeFolderPath("./Rho/./Sub", "Fallback")).toBe("Rho/Sub");
+	});
+
+	it("returns fallback for empty or whitespace-only input", () => {
+		expect(normalizeFolderPath("", "Fallback")).toBe("Fallback");
+		expect(normalizeFolderPath("   ", "Fallback")).toBe("Fallback");
+		expect(normalizeFolderPath("/", "Fallback")).toBe("Fallback");
+		expect(normalizeFolderPath("///", "Fallback")).toBe("Fallback");
+	});
+
+	it("returns fallback for non-string inputs", () => {
+		// @ts-expect-error - intentionally passing wrong type
+		expect(normalizeFolderPath(null, "Fallback")).toBe("Fallback");
+		// @ts-expect-error - intentionally passing wrong type
+		expect(normalizeFolderPath(undefined, "Fallback")).toBe("Fallback");
+	});
+
+	it("trims whitespace from segments", () => {
+		expect(normalizeFolderPath("  Rho  /  Sub  ", "Fallback")).toBe(
+			"Rho/Sub"
+		);
+	});
+});

--- a/src/settings/validation.ts
+++ b/src/settings/validation.ts
@@ -1,0 +1,39 @@
+export const MIN_SYNC_CONCURRENCY = 1;
+export const MAX_SYNC_CONCURRENCY = 20;
+
+/**
+ * Clamps a user-supplied value to the allowed sync concurrency range.
+ * Returns `fallback` when the value is not a parseable positive integer
+ * (e.g. when the user clears the input or types non-numeric text).
+ */
+export function clampSyncConcurrency(
+	value: string | number,
+	fallback: number
+): number {
+	const num =
+		typeof value === "number" ? value : parseInt(String(value).trim(), 10);
+	if (!Number.isFinite(num) || Number.isNaN(num)) return fallback;
+	const floored = Math.floor(num);
+	if (floored < MIN_SYNC_CONCURRENCY) return MIN_SYNC_CONCURRENCY;
+	if (floored > MAX_SYNC_CONCURRENCY) return MAX_SYNC_CONCURRENCY;
+	return floored;
+}
+
+/**
+ * Normalizes a vault-relative folder path. Strips leading / trailing
+ * separators, collapses duplicates, filters out `.` and `..` segments
+ * (which would allow escaping the vault), and trims whitespace.
+ * Returns `fallback` when the resulting path is empty.
+ */
+export function normalizeFolderPath(
+	input: string,
+	fallback: string
+): string {
+	if (typeof input !== "string") return fallback;
+	const segments = input
+		.split(/[\\/]+/)
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0 && s !== "." && s !== "..");
+	if (segments.length === 0) return fallback;
+	return segments.join("/");
+}


### PR DESCRIPTION
## Summary

`RhoReaderSettingTab` accepted any input the user typed, which meant:

- `syncConcurrency` had no upper bound and silently kept the previous
  value when the input was cleared (the `if (num >= 1)` branch
  rejected `NaN` without feedback).
- `rhoFolder` accepted any string — including leading `/` or `..`
  segments — which would then be passed to `vault.createFolder` and
  misbehave.

This PR adds a small `src/settings/validation.ts` module with two
helpers and wires them into both the settings tab and
`loadSettings` so stale values in `data.json` are corrected on load.

- `clampSyncConcurrency` clamps to `1..20`, floors fractions, and
  falls back when the input is empty / non-numeric / non-finite.
- `normalizeFolderPath` strips leading/trailing separators, collapses
  duplicates, converts backslashes, filters `.` / `..` segments, and
  falls back when the result is empty.

The settings tab now:
- Reflects the clamped/normalized value in the input field on blur.
- Uses `type=number` with `min`/`max` for the concurrency box and
  surfaces the allowed range in the description text.
- Tolerates a temporarily empty concurrency input while the user is
  editing, committing the clamped value on blur.

## Test plan

- [x] `npm test` — 116 tests pass, including 17 new
      `src/settings/validation.test.ts` cases covering empty input,
      non-numeric input, clamping bounds, leading/trailing separators,
      `.`/`..` filtering, and backslash conversion.
- [x] `npx tsc -noEmit -skipLibCheck` — clean.
- [ ] Manually verify in Obsidian: entering `../Rho` normalizes to
      `Rho` on blur; entering `9999` clamps to `20`; clearing the
      concurrency box restores the default on blur.

https://claude.ai/code/session_01J3vMD1xLjkUusdFqUNrFmz