### PR TITLE
fix: mobile unread count not updating when opening a post

### DIFF
--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -102,13 +102,13 @@ export class RhoReaderPane extends ItemView {
 
 			if (post.link) {
 				card.style.cursor = "pointer";
-				card.addEventListener("click", () => {
+				card.addEventListener("click", async () => {
 					if (
 						this.currentFeedUrl &&
 						!this.plugin.isPostRead(this.currentFeedUrl, post)
 					) {
-						this.plugin.markPostRead(this.currentFeedUrl, post);
 						card.addClass("rho-reader-card--read");
+						await this.plugin.markPostRead(this.currentFeedUrl, post);
 					}
 					window.open(post.link, "_blank");
 				});


### PR DESCRIPTION
The click handler fired `markPostRead` without awaiting it and then
immediately called `window.open(..., "_blank")`. On mobile, handing the
URL to the system browser backgrounds Obsidian, which suspends the
pending vault reads/writes inside `markPostRead` →
`updateFeedCountsFromFiles` before the feed file's `rho_unread_posts`
frontmatter is rewritten. On desktop the window stays active so the
writes complete.

Await `markPostRead` before `window.open` so the frontmatter is
persisted prior to the handoff.

https://claude.ai/code/session_01TTqmmtAgBs4JioMDXZfStY