### PR TITLE
fix: optimistically update rho_unread_posts on mark read/unread

### DIFF
--- a/src/commands/utils/index.ts
+++ b/src/commands/utils/index.ts
@@ -18,5 +18,6 @@ export {
 	getPostsForFeed,
 	countPostsForFeed,
 	updateFeedCountsFromFiles,
+	getFeedCounts,
 	setFeedCounts,
 } from "./postFiles";

--- a/src/commands/utils/postFiles.ts
+++ b/src/commands/utils/postFiles.ts
@@ -217,6 +217,21 @@ export async function updateFeedCountsFromFiles(
 	await setFeedCounts(plugin, feedUrl, total, unread);
 }
 
+export function getFeedCounts(
+	plugin: RhoReader,
+	feedUrl: string
+): { total: number; unread: number } | null {
+	const feedFile = findFileForFeedUrl(plugin, feedUrl);
+	if (!feedFile) return null;
+	const cache = plugin.app.metadataCache.getFileCache(feedFile);
+	const fm = cache?.frontmatter;
+	if (!fm) return null;
+	return {
+		total: typeof fm.rho_all_posts === "number" ? fm.rho_all_posts : 0,
+		unread: typeof fm.rho_unread_posts === "number" ? fm.rho_unread_posts : 0,
+	};
+}
+
 export async function setFeedCounts(
 	plugin: RhoReader,
 	feedUrl: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
 	findExistingPostFile,
 	setPostReadState,
 	updateFeedCountsFromFiles,
+	getFeedCounts,
 	setFeedCounts,
 	createPostFile,
 	findFileForFeedUrl,
@@ -188,6 +189,13 @@ export default class RhoReader extends Plugin {
 
 	async markPostRead(feedUrl: string, post: FeedPost) {
 		post.read = true;
+		const counts = getFeedCounts(this, feedUrl);
+		if (counts) {
+			const hasFile = findExistingPostFile(this, feedUrl, getPostKey(post));
+			const total = hasFile ? counts.total : counts.total + 1;
+			const unread = Math.max(0, counts.unread - 1);
+			setFeedCounts(this, feedUrl, total, unread);
+		}
 		const postKey = getPostKey(post);
 		let file = findExistingPostFile(this, feedUrl, postKey);
 		if (!file) {
@@ -233,6 +241,10 @@ export default class RhoReader extends Plugin {
 
 	async markPostUnread(feedUrl: string, post: FeedPost) {
 		post.read = false;
+		const counts = getFeedCounts(this, feedUrl);
+		if (counts) {
+			setFeedCounts(this, feedUrl, counts.total, counts.unread + 1);
+		}
 		const postKey = getPostKey(post);
 		const file = findExistingPostFile(this, feedUrl, postKey);
 		if (file) {


### PR DESCRIPTION
## Summary

- Adds `getFeedCounts()` helper that reads current `rho_all_posts` / `rho_unread_posts` from Obsidian's metadata cache (synchronous, no disk I/O)
- `markPostRead` and `markPostUnread` now write adjusted counts immediately before any file operations, eliminating the visible delay in the feed file frontmatter
- The existing `updateFeedCountsFromFiles` disk recount still runs afterward as a background consistency check

## Test plan

- [ ] Open a feed with several unread posts; click a post — verify `rho_unread_posts` in the feed file updates instantly
- [ ] Right-click a post → "Mark as read" — same check
- [ ] Right-click a read post → "Mark as unread" — verify count increments instantly
- [ ] "Mark all as read" — was already optimistic, confirm still works
- [x] All 116 existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)