### PR TITLE
refactor: file-open handler and restore reader pane on plugin load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,26 +65,8 @@ export default class RhoReader extends Plugin {
 		);
 
 		this.registerEvent(
-			this.app.workspace.on("file-open", async (file: TFile | null) => {
-				let feedUrl: string | null = null;
-				if (file) {
-					const fileCache = this.app.metadataCache.getFileCache(file);
-					if (fileCache?.frontmatter?.rho_feed_url) {
-						// Post file opened (e.g. via "Take notes") — keep current feed displayed
-						return;
-					}
-					feedUrl = fileCache?.frontmatter?.feed_url || null;
-				}
-				let leaf =
-					this.app.workspace.getLeavesOfType(VIEW_TYPE_RHO_READER)[0];
-				if (!leaf) {
-					const rightLeaf = this.app.workspace.getRightLeaf(false);
-					if (!rightLeaf) return;
-					await rightLeaf.setViewState({ type: VIEW_TYPE_RHO_READER });
-					leaf = rightLeaf;
-				}
-				const view = leaf.view as RhoReaderPane;
-				view.setFeedUrl(feedUrl);
+			this.app.workspace.on("file-open", (file: TFile | null) => {
+				this.openReaderForFile(file);
 			})
 		);
 
@@ -99,7 +81,31 @@ export default class RhoReader extends Plugin {
 		this.app.workspace.onLayoutReady(() => {
 			this.migrateReadState();
 			this.clearStaleSyncStatuses();
+			// Re-open the reader pane for the active file after plugin (re)load,
+			// since `file-open` won't fire for a file that's already open.
+			this.openReaderForFile(this.app.workspace.getActiveFile());
 		});
+	}
+
+	private async openReaderForFile(file: TFile | null): Promise<void> {
+		let feedUrl: string | null = null;
+		if (file) {
+			const fileCache = this.app.metadataCache.getFileCache(file);
+			if (fileCache?.frontmatter?.rho_feed_url) {
+				// Post file opened (e.g. via "Take notes") — keep current feed displayed
+				return;
+			}
+			feedUrl = fileCache?.frontmatter?.feed_url || null;
+		}
+		let leaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_RHO_READER)[0];
+		if (!leaf) {
+			const rightLeaf = this.app.workspace.getRightLeaf(false);
+			if (!rightLeaf) return;
+			await rightLeaf.setViewState({ type: VIEW_TYPE_RHO_READER });
+			leaf = rightLeaf;
+		}
+		const view = leaf.view as RhoReaderPane;
+		view.setFeedUrl(feedUrl);
 	}
 
 	private async migrateReadState(): Promise<void> {


### PR DESCRIPTION
## Summary
This PR refactors the file-open event handler into a reusable method and ensures the reader pane is restored when the plugin loads or reloads, even if a file is already open.

## Key Changes
- Extracted the file-open event handler logic into a new private method `openReaderForFile()` to eliminate code duplication
- Removed the `async` keyword from the file-open event listener since the extracted method handles async operations
- Added a call to `openReaderForFile()` in the `onLayoutReady()` callback to restore the reader pane for the currently active file after plugin load/reload
- Added explanatory comment clarifying why this is necessary (file-open event doesn't fire for already-open files)

## Implementation Details
The `openReaderForFile()` method encapsulates the logic for:
- Extracting the feed URL from file frontmatter
- Handling the special case where `rho_feed_url` is present (preserving current feed)
- Creating or retrieving the RhoReader view pane
- Setting the appropriate feed URL on the view

This ensures consistent behavior whether a file is opened while the plugin is active or the plugin is loaded with a file already open.

https://claude.ai/code/session_01KSUPgKCJqypua6WS6QwvyR