### PR TITLE
feat: add version display to RhoReader landing page

### DIFF
--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -394,6 +394,11 @@ export class RhoReaderPane extends ItemView {
 			text: "Reading companion for Obsidian",
 		});
 
+		landing.createEl("div", {
+			cls: "rho-reader-landing-version",
+			text: `v${this.plugin.manifest.version}`,
+		});
+
 		const actions = landing.createEl("div", {
 			cls: "rho-reader-landing-actions",
 		});

--- a/styles.css
+++ b/styles.css
@@ -124,6 +124,12 @@
 .rho-reader-landing-subtitle {
 	font-size: var(--font-ui-small);
 	color: var(--text-muted);
+	margin-bottom: 4px;
+}
+
+.rho-reader-landing-version {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-faint);
 	margin-bottom: 24px;
 }
 


### PR DESCRIPTION
## Summary
Added a version number display to the RhoReader landing page, showing the plugin version below the subtitle.

## Changes
- Added new `.rho-reader-landing-version` CSS class with smaller font size and faint text color
- Adjusted `.rho-reader-landing-subtitle` margin-bottom from 24px to 4px to accommodate the new version element
- Created a new div element on the landing page that displays the plugin version (pulled from `manifest.version`)

## Implementation Details
- The version is displayed using a new dedicated CSS class with `font-ui-smaller` size and `text-faint` color for visual hierarchy
- The version element is inserted between the subtitle and the actions section
- Uses the plugin's manifest version property to ensure the displayed version stays in sync with the actual plugin version

https://claude.ai/code/session_01FUqkYxuphjWuWAa4ZV9MSr