### PR TITLE
feat: add user feedback notice when opening posts in browser

### DIFF
--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, Menu, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
+import { App, ItemView, Menu, Notice, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
 import type RhoReader from "../main";
 import type { FeedPost } from "../types";
 import { syncAllRssFeeds } from "../commands/syncAllRssFeeds";
@@ -104,6 +104,7 @@ export class RhoReaderPane extends ItemView {
 			if (post.link) {
 				card.style.cursor = "pointer";
 				card.addEventListener("click", async () => {
+					new Notice("Opening in browser...");
 					if (
 						this.currentFeedUrl &&
 						!this.plugin.isPostRead(this.currentFeedUrl, post)


### PR DESCRIPTION
## Summary
Added a user-facing notification to provide feedback when a post link is opened in the browser from the RhoReader pane.

## Changes
- Imported `Notice` from the Obsidian API
- Display a "Opening in browser..." notice when a user clicks on a post card to open its link

## Details
This improvement enhances the user experience by providing immediate visual feedback that the application is responding to the click action, making the interaction feel more responsive and intentional.

https://claude.ai/code/session_0154VmEuyDajx1n4XMLN6GHX