### PR TITLE
feat: inline spinner on clicked post while browser opens

### DIFF
--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, Menu, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
+import { App, ItemView, Menu, Notice, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
 import type RhoReader from "../main";
 import type { FeedPost } from "../types";
 import { syncAllRssFeeds } from "../commands/syncAllRssFeeds";
@@ -104,6 +104,7 @@ export class RhoReaderPane extends ItemView {
 			if (post.link) {
 				card.style.cursor = "pointer";
 				card.addEventListener("click", async () => {
+					new Notice("Opening in browser...");
 					if (
 						this.currentFeedUrl &&
 						!this.plugin.isPostRead(this.currentFeedUrl, post)

--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, Menu, Notice, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
+import { App, ItemView, Menu, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
 import type RhoReader from "../main";
 import type { FeedPost } from "../types";
 import { syncAllRssFeeds } from "../commands/syncAllRssFeeds";
@@ -104,7 +104,15 @@ export class RhoReaderPane extends ItemView {
 			if (post.link) {
 				card.style.cursor = "pointer";
 				card.addEventListener("click", async () => {
-					new Notice("Opening in browser...");
+					card.addClass("rho-reader-card--opening");
+					const spinner = card.createSpan({
+						cls: "rho-reader-card-spinner",
+					});
+					setIcon(spinner, "loader-2");
+					window.setTimeout(() => {
+						spinner.remove();
+						card.removeClass("rho-reader-card--opening");
+					}, 1500);
 					if (
 						this.currentFeedUrl &&
 						!this.plugin.isPostRead(this.currentFeedUrl, post)

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,29 @@
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 8px;
 	padding: 12px;
-	transition: box-shadow 0.15s ease;
+	position: relative;
+	transition: box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.rho-reader-card--opening {
+	opacity: 0.6;
+	pointer-events: none;
+}
+
+.rho-reader-card-spinner {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-muted);
+}
+
+.rho-reader-card-spinner svg {
+	width: 14px;
+	height: 14px;
+	animation: rho-reader-spin 1s linear infinite;
 }
 
 .rho-reader-card:hover {


### PR DESCRIPTION
## Summary
- Opening an external link has a perceptible delay, but the mark-as-read strikeout and unread-count decrement happen immediately, which made the click feel like nothing was loading
- Show a small spinner in the top-right of the clicked card and dim the card slightly, so the feedback is tied to the exact card that was clicked
- Indicator clears after 1.5s; the card is also made `pointer-events: none` during this window to avoid double-clicks

## Notes
- First iteration used a top-of-screen `Notice` ("Opening in browser...") — kept as the first commit for review context, then replaced with the inline approach in the follow-up commit.

## Test plan
- [x] Click an unread post: spinner appears in the card's top-right, title gets strikeout, unread count decrements, browser tab opens
- [x] Click an already-read post: spinner still appears briefly and clears; no duplicate mark-read work
- [x] Rapid double-click on a card: second click is suppressed while `--opening` is active
- [x] Spinner and dim fully clear after ~1.5s

https://claude.ai/code/session_0154VmEuyDajx1n4XMLN6GHX