### PR TITLE
chore: tidy plugin metadata

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Rho Reader",
 	"version": "0.4.0",
 	"minAppVersion": "1.9.0",
-	"description": "Read and manage RSS feeds.",
+	"description": "Read and manage RSS feeds",
 	"author": "Vishnu Bharathi",
 	"authorUrl": "https://vishnubharathi.codes/",
 	"isDesktopOnly": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "rho-reader",
 	"version": "0.4.0",
-	"description": "Read and manage RSS feeds.",
+	"description": "Read and manage RSS feeds",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
@@ -12,7 +12,7 @@
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],
-	"author": "",
+	"author": "Vishnu Bharathi",
 	"license": "MIT",
 	"devDependencies": {
 		"@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
Bundles two quick metadata fixes from `launch-checklist.html` (R3 + R5).

### Changes
- **R3** — Drop the trailing period from `description` in both `manifest.json` and `package.json`. The Obsidian community directory convention is a short description with no trailing period.
- **R5** — Set `package.json` `author` (was empty) to `Vishnu Bharathi`, matching `manifest.json`.

No functional change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GayZbD614ffRPNo7vN9uwq)_