### PR TITLE
refactor: route diagnostics through a debug-gated logger

### DIFF
--- a/src/commands/exportOpml/exportOpml.ts
+++ b/src/commands/exportOpml/exportOpml.ts
@@ -1,6 +1,7 @@
 import { Notice, TFile } from "obsidian";
 import type RhoReader from "../../main";
 import { serializeOpml, OpmlFeed } from "../utils/parseOpml";
+import { logError } from "../../log";
 
 export async function exportOpml(plugin: RhoReader): Promise<void> {
 	plugin.statusBar.setProcessing(true, "Exporting OPML");
@@ -39,7 +40,7 @@ export async function exportOpml(plugin: RhoReader): Promise<void> {
 			`Exported ${feeds.length} feed${feeds.length !== 1 ? "s" : ""} to ${exportPath}.`,
 		);
 	} catch (err) {
-		console.error("Failed to export OPML:", err);
+		logError("Failed to export OPML:", err);
 		new Notice("Failed to export OPML file.");
 	} finally {
 		plugin.statusBar.setProcessing(false);

--- a/src/commands/importOpml/importOpml.ts
+++ b/src/commands/importOpml/importOpml.ts
@@ -2,6 +2,7 @@ import { Notice, TFile } from "obsidian";
 import * as yaml from "js-yaml";
 import type RhoReader from "../../main";
 import { parseOpml, updateFeedFrontmatter, setFeedSyncStatus } from "../utils";
+import { logError } from "../../log";
 import {
 	ImportOpmlModal,
 	FeedToImport,
@@ -115,7 +116,7 @@ async function performImport(
 					await updateFeedFrontmatter(plugin, feed.xmlUrl, createdFile);
 					await setFeedSyncStatus(plugin, createdFile, "synced");
 				} catch (err) {
-					console.error(`Failed to sync imported feed ${feed.xmlUrl}:`, err);
+					logError(`Failed to sync imported feed ${feed.xmlUrl}:`, err);
 					await setFeedSyncStatus(plugin, createdFile, "error");
 				}
 				// Ensure per-feed posts folder exists
@@ -129,7 +130,7 @@ async function performImport(
 
 		new Notice(`Imported ${imported} feed${imported !== 1 ? "s" : ""}.`);
 	} catch (err) {
-		console.error("Failed to import OPML:", err);
+		logError("Failed to import OPML:", err);
 		new Notice("Failed to import OPML file.");
 	} finally {
 		plugin.statusBar.setProcessing(false);
@@ -161,7 +162,7 @@ export async function importOpml(plugin: RhoReader): Promise<void> {
 				performImport(plugin, preview.toImport);
 			}).open();
 		} catch (err) {
-			console.error("Failed to parse OPML:", err);
+			logError("Failed to parse OPML:", err);
 			new Notice("Failed to parse OPML file.");
 		}
 	};

--- a/src/commands/syncAllRssFeeds/syncAllRssFeeds.ts
+++ b/src/commands/syncAllRssFeeds/syncAllRssFeeds.ts
@@ -1,6 +1,7 @@
 import type RhoReader from "../../main";
 import { updateFeedFrontmatter, setFeedSyncStatus } from "../utils";
 import { TFile } from "obsidian";
+import { logError } from "../../log";
 
 async function syncFeed(
 	plugin: RhoReader,
@@ -12,7 +13,7 @@ async function syncFeed(
 		await updateFeedFrontmatter(plugin, feedUrl, file);
 		await setFeedSyncStatus(plugin, file, "synced");
 	} catch (err) {
-		console.error(`Failed to sync feed ${feedUrl}:`, err);
+		logError(`Failed to sync feed ${feedUrl}:`, err);
 		await setFeedSyncStatus(plugin, file, "error");
 	}
 }

--- a/src/commands/syncRssFeed/syncRssFeed.test.ts
+++ b/src/commands/syncRssFeed/syncRssFeed.test.ts
@@ -34,27 +34,22 @@ function createMockPlugin(options: {
 describe("syncRssFeed", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		vi.spyOn(console, "error").mockImplementation(() => {});
 	});
 
-	it("should log and return when no active file", async () => {
+	it("should return without syncing when no active file", async () => {
 		const plugin = createMockPlugin({ activeFile: null });
 
 		await syncRssFeed(plugin);
 
-		expect(console.error).toHaveBeenCalledWith("[Rho Reader] No active file.");
 		expect(updateFeedFrontmatter).not.toHaveBeenCalled();
 	});
 
-	it("should log and return when active file has no feed_url", async () => {
+	it("should return without syncing when active file has no feed_url", async () => {
 		const mockFile = { path: "test.md" } as TFile;
 		const plugin = createMockPlugin({ activeFile: mockFile });
 
 		await syncRssFeed(plugin);
 
-		expect(console.error).toHaveBeenCalledWith(
-			"[Rho Reader] No feed_url property found in frontmatter."
-		);
 		expect(updateFeedFrontmatter).not.toHaveBeenCalled();
 	});
 

--- a/src/commands/syncRssFeed/syncRssFeed.ts
+++ b/src/commands/syncRssFeed/syncRssFeed.ts
@@ -1,18 +1,17 @@
 import type RhoReader from "../../main";
 import { updateFeedFrontmatter, setFeedSyncStatus } from "../utils";
+import { logError } from "../../log";
 
 export async function syncRssFeed(plugin: RhoReader): Promise<void> {
 	const file =
 		plugin.app.workspace.getActiveFile?.() ||
 		plugin.app.workspace.getActiveFile?.call(plugin.app.workspace);
 	if (!file) {
-		console.error("[Rho Reader] No active file.");
 		return;
 	}
 	const fileCache = plugin.app.metadataCache.getFileCache(file);
 	const feedUrl = fileCache?.frontmatter?.feed_url;
 	if (!feedUrl) {
-		console.error("[Rho Reader] No feed_url property found in frontmatter.");
 		return;
 	}
 
@@ -21,7 +20,7 @@ export async function syncRssFeed(plugin: RhoReader): Promise<void> {
 		await updateFeedFrontmatter(plugin, feedUrl, file);
 		await setFeedSyncStatus(plugin, file, "synced");
 	} catch (err) {
-		console.error(`Failed to sync feed ${feedUrl}:`, err);
+		logError(`Failed to sync feed ${feedUrl}:`, err);
 		await setFeedSyncStatus(plugin, file, "error");
 	}
 }

--- a/src/commands/utils/frontmatter.ts
+++ b/src/commands/utils/frontmatter.ts
@@ -1,6 +1,7 @@
 import * as yaml from "js-yaml";
 import { TFile } from "obsidian";
 import type RhoReader from "../../main";
+import { logError } from "../../log";
 
 /**
  * Reads a markdown file's YAML frontmatter, lets the mutator modify it,
@@ -34,11 +35,7 @@ export async function modifyFrontmatter(
 	try {
 		fm = (yaml.load(fmRaw) as Record<string, unknown>) || {};
 	} catch (e) {
-		console.error(
-			"[Rho Reader] Failed to parse frontmatter:",
-			file.path,
-			e
-		);
+		logError("Failed to parse frontmatter:", file.path, e);
 		return false;
 	}
 

--- a/src/commands/utils/parseRssFeedItems.test.ts
+++ b/src/commands/utils/parseRssFeedItems.test.ts
@@ -1,11 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { parseRssFeedItems } from "./parseRssFeedItems";
 
 describe("parseRssFeedItems", () => {
-	beforeEach(() => {
-		vi.spyOn(console, "error").mockImplementation(() => {});
-	});
-
 	it("should parse RSS 2.0 items correctly", () => {
 		const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
 			<rss version="2.0">
@@ -50,7 +46,6 @@ describe("parseRssFeedItems", () => {
 
 		const posts = parseRssFeedItems(emptyXml, "https://example.com/empty.xml");
 		expect(posts).toHaveLength(0);
-		expect(console.error).toHaveBeenCalled();
 	});
 
 	it("should prefer RSS items over Atom entries when both exist", () => {

--- a/src/commands/utils/parseRssFeedItems.ts
+++ b/src/commands/utils/parseRssFeedItems.ts
@@ -1,6 +1,7 @@
 import type { FeedPost } from "../../types";
 import { parseJsonFeedItems } from "./parseJsonFeedItems";
 import { resolveUrl } from "./resolveUrl";
+import { logError } from "../../log";
 
 export function parseRssFeedItems(text: string, feedUrl: string): FeedPost[] {
 	// Detect JSON Feed format before attempting XML parsing
@@ -26,11 +27,7 @@ export function parseRssFeedItems(text: string, feedUrl: string): FeedPost[] {
 		xmlDoc = parser.parseFromString(text, "text/html");
 		parserError = xmlDoc.querySelector("parsererror");
 		if (parserError) {
-			console.error(
-				"[Rho Reader] RSS XML parse error:",
-				feedUrl,
-				parserError.textContent
-			);
+			logError("RSS XML parse error:", feedUrl, parserError.textContent);
 			return [];
 		}
 	}
@@ -39,10 +36,7 @@ export function parseRssFeedItems(text: string, feedUrl: string): FeedPost[] {
 	const entries = xmlDoc.querySelectorAll("entry");
 
 	if (items.length === 0 && entries.length === 0) {
-		console.error(
-			"[Rho Reader] No <item> or <entry> elements found in feed:",
-			feedUrl
-		);
+		logError("No <item> or <entry> elements found in feed:", feedUrl);
 		return [];
 	}
 

--- a/src/commands/utils/pendingReads.ts
+++ b/src/commands/utils/pendingReads.ts
@@ -2,6 +2,7 @@ import type RhoReader from "../../main";
 import type { FeedPost } from "../../types";
 import { getPostKey } from "./postFiles";
 import { markPostRead } from "./readState";
+import { logError } from "../../log";
 
 type PendingReadEntry = {
 	feedUrl: string;
@@ -35,7 +36,7 @@ function writeQueue(plugin: RhoReader, queue: PendingReadEntry[]): void {
 	try {
 		localStorage.setItem(storageKey(plugin), JSON.stringify(queue));
 	} catch (err) {
-		console.error("[Rho Reader] Failed to persist pending reads:", err);
+		logError("Failed to persist pending reads:", err);
 	}
 }
 
@@ -75,7 +76,7 @@ async function runDrain(plugin: RhoReader): Promise<void> {
 		try {
 			await markPostRead(plugin, entry.feedUrl, entry.post);
 		} catch (err) {
-			console.error("[Rho Reader] pending read drain failed:", err);
+			logError("pending read drain failed:", err);
 		}
 		const current = readQueue(plugin);
 		writeQueue(

--- a/src/commands/utils/postFiles.ts
+++ b/src/commands/utils/postFiles.ts
@@ -5,6 +5,7 @@ import type { FeedPost } from "../../types";
 import { sanitizeFileName } from "./sanitizeFileName";
 import { findFileForFeedUrl } from "./findFileForFeedUrl";
 import { modifyFrontmatter } from "./frontmatter";
+import { logError } from "../../log";
 
 function simpleHash(str: string): string {
 	let hash = 5381;
@@ -88,7 +89,7 @@ export async function createPostFile(
 	try {
 		return await plugin.app.vault.create(filePath, content);
 	} catch (err) {
-		console.error("[Rho Reader] Failed to create post file:", filePath, err);
+		logError("Failed to create post file:", filePath, err);
 		return null;
 	}
 }
@@ -123,7 +124,7 @@ export async function setPostReadState(
 			fm.read_at = read ? (readAt ?? Date.now()) : 0;
 		});
 	} catch (err) {
-		console.error("[Rho Reader] Failed to set post read state:", err);
+		logError("Failed to set post read state:", err);
 	}
 }
 
@@ -162,7 +163,7 @@ export async function setPostTags(
 			fm.rho_tags = tags;
 		});
 	} catch (err) {
-		console.error("[Rho Reader] Failed to set post tags:", err);
+		logError("Failed to set post tags:", err);
 	}
 }
 
@@ -258,6 +259,6 @@ export async function setFeedCounts(
 			}
 		}
 	} catch (err) {
-		console.error("[Rho Reader] Failed to update feed counts:", err);
+		logError("Failed to update feed counts:", err);
 	}
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,10 @@
+// Routes plugin diagnostics through a single switch so the console stays
+// quiet for users by default. Flip DEBUG to surface internal errors while
+// developing.
+const DEBUG = false;
+
+export function logError(...args: unknown[]): void {
+	if (DEBUG) {
+		console.error("[Rho Reader]", ...args);
+	}
+}

--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -5,6 +5,7 @@ import { syncAllRssFeeds } from "../commands/syncAllRssFeeds";
 import { importOpml } from "../commands/importOpml";
 import { openRssFeedReader } from "../commands/openRssFeedReader";
 import { updateFeedFrontmatter, findFileForFeedUrl, getPostsForFeed, findExistingPostFile, getPostKey, setPostTags, getAllTagsForFeed, setFeedSyncStatus, enqueuePendingRead, drainPendingReads, markPostRead, markPostUnread, markAllPostsRead, setFeedCounts } from "../commands/utils";
+import { logError } from "../log";
 
 export const VIEW_TYPE_RHO_READER = "rho-reader-pane";
 
@@ -480,7 +481,7 @@ export class RhoReaderPane extends ItemView {
 				);
 				await setFeedSyncStatus(this.plugin, file, "synced");
 			} catch (err) {
-				console.error("Failed to sync feed:", err);
+				logError("Failed to sync feed:", err);
 				await setFeedSyncStatus(this.plugin, file, "error");
 			}
 		}


### PR DESCRIPTION
Addresses R1 from `launch-checklist.html` — Obsidian's plugin guidelines discourage logging to the console in production.

### Changes
- Add `src/log.ts` with a `logError(...)` helper gated behind a `DEBUG` constant (off by default), so the console stays quiet for users but diagnostics are one flag-flip away when developing.
- Route every `console.error` call site (~16 across views, commands, and utils) through `logError`. Redundant `[Rho Reader]` prefixes are dropped since the helper adds one.
- Remove the two guard logs in `syncRssFeed` ("no active file" / "no feed_url") entirely — these are normal control flow, not errors.

### Scope note
This is intentionally noise-only (R1). It does **not** add user-facing `Notice` messages for silent failures — that's R6, left as a separate follow-up.

### Testing
- `npm run build` clean (tsc + esbuild).
- `npm test` — 116/116 pass. Updated two tests that asserted `console.error` was called to assert behavior instead (early return / empty result).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GayZbD614ffRPNo7vN9uwq)_