### PR TITLE
feat: surface RSS sync failures via Notice

### DIFF
--- a/src/commands/syncAllRssFeeds/syncAllRssFeeds.ts
+++ b/src/commands/syncAllRssFeeds/syncAllRssFeeds.ts
@@ -1,19 +1,21 @@
 import type RhoReader from "../../main";
 import { updateFeedFrontmatter, setFeedSyncStatus } from "../utils";
-import { TFile } from "obsidian";
+import { Notice, TFile } from "obsidian";
 
 async function syncFeed(
 	plugin: RhoReader,
 	file: TFile,
 	feedUrl: string
-): Promise<void> {
+): Promise<boolean> {
 	await setFeedSyncStatus(plugin, file, "syncing");
 	try {
 		await updateFeedFrontmatter(plugin, feedUrl, file);
 		await setFeedSyncStatus(plugin, file, "synced");
+		return true;
 	} catch (err) {
 		console.error(`Failed to sync feed ${feedUrl}:`, err);
 		await setFeedSyncStatus(plugin, file, "error");
+		return false;
 	}
 }
 
@@ -37,13 +39,17 @@ export async function syncAllRssFeeds(plugin: RhoReader): Promise<void> {
 
 		// Sync feeds with concurrency limit
 		const concurrency = plugin.settings.syncConcurrency;
+		const failures: string[] = [];
 		let index = 0;
 
 		async function worker(): Promise<void> {
 			while (index < feedFiles.length) {
 				const i = index++;
 				const { file, feedUrl } = feedFiles[i];
-				await syncFeed(plugin, file, feedUrl);
+				const ok = await syncFeed(plugin, file, feedUrl);
+				if (!ok) {
+					failures.push(file.basename);
+				}
 			}
 		}
 
@@ -52,6 +58,21 @@ export async function syncAllRssFeeds(plugin: RhoReader): Promise<void> {
 			() => worker()
 		);
 		await Promise.all(workers);
+
+		if (feedFiles.length === 0) return;
+		if (failures.length === 0) {
+			new Notice(
+				`Synced ${feedFiles.length} feed${feedFiles.length === 1 ? "" : "s"}.`
+			);
+		} else {
+			const synced = feedFiles.length - failures.length;
+			const preview = failures.slice(0, 3).join(", ");
+			const overflow =
+				failures.length > 3 ? ` and ${failures.length - 3} more` : "";
+			new Notice(
+				`Synced ${synced} feed${synced === 1 ? "" : "s"}, ${failures.length} failed: ${preview}${overflow}.`
+			);
+		}
 	} finally {
 		plugin.statusBar.setProcessing(false);
 	}

--- a/src/commands/syncRssFeed/syncRssFeed.ts
+++ b/src/commands/syncRssFeed/syncRssFeed.ts
@@ -1,3 +1,4 @@
+import { Notice } from "obsidian";
 import type RhoReader from "../../main";
 import { updateFeedFrontmatter, setFeedSyncStatus } from "../utils";
 
@@ -23,5 +24,6 @@ export async function syncRssFeed(plugin: RhoReader): Promise<void> {
 	} catch (err) {
 		console.error(`Failed to sync feed ${feedUrl}:`, err);
 		await setFeedSyncStatus(plugin, file, "error");
+		new Notice(`Couldn't sync ${file.basename}.`);
 	}
 }

--- a/src/views/RhoReaderPane.ts
+++ b/src/views/RhoReaderPane.ts
@@ -1,4 +1,4 @@
-import { App, ItemView, Menu, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
+import { App, ItemView, Menu, Notice, SuggestModal, WorkspaceLeaf, setIcon } from "obsidian";
 import type RhoReader from "../main";
 import type { FeedPost } from "../types";
 import { syncAllRssFeeds } from "../commands/syncAllRssFeeds";
@@ -482,6 +482,7 @@ export class RhoReaderPane extends ItemView {
 			} catch (err) {
 				console.error("Failed to sync feed:", err);
 				await setFeedSyncStatus(this.plugin, file, "error");
+				new Notice(`Couldn't sync ${file.basename}.`);
 			}
 		}
 		this.isLoading = false;


### PR DESCRIPTION
Addresses R6 from `launch-checklist.html` — RSS sync failures used to be silent to the user.

### Changes
- **`syncRssFeed`** (single-feed command) and the **reader pane refresh** now show `Couldn't sync <feed>.` as a `Notice` on failure.
- **`syncAllRssFeeds`** (bulk) collects failures and emits a single summary `Notice` at the end:
  - All good → `Synced 12 feeds.`
  - Some failed → `Synced 9 feeds, 3 failed: feed-a, feed-b, feed-c.` (truncates at 3 names with `and N more`).

This avoids the per-feed Notice spam concern you raised — a Sync-All over 50 feeds produces exactly one summary toast no matter how many fail.

### Out of scope
Bulk-import (`importOpml`) follows the same silent-per-feed pattern internally; intentionally left for a follow-up since the user-facing scope of R6 was sync.

Per-feed error **details** (storing the message on the feed file for later display) are tracked separately as a feature issue.

### Testing
- `npm run build` clean (tsc + esbuild).
- `npm test` — 116/116 pass (no test changes needed; behavior at the boundary changed but no test asserted on the old silent behavior).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GayZbD614ffRPNo7vN9uwq)_