### PR TITLE
ci: add build provenance attestation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -29,8 +31,12 @@ jobs:
       - name: Restore manifest.json
         run: git checkout -- manifest.json
 
-      - name: Create plugin zip
-        run: zip rho-reader.zip main.js manifest.json styles.css
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            styles.css
 
       - name: Create draft release
         uses: softprops/action-gh-release@v2
@@ -40,5 +46,4 @@ jobs:
             main.js
             manifest.json
             styles.css
-            rho-reader.zip
           generate_release_notes: true


### PR DESCRIPTION
## Summary
Updated the release workflow to generate build provenance attestations for released artifacts instead of creating a zip file, improving supply chain security.

## Key Changes
- Added `id-token: write` and `attestations: write` permissions to the release job
- Replaced the "Create plugin zip" step with "Attest build provenance" using `actions/attest-build-provenance@v2`
- Configured provenance attestation for `main.js` and `styles.css` artifacts
- Removed `rho-reader.zip` from the release assets, now releasing individual files with attestations instead

## Implementation Details
The workflow now uses GitHub's native build provenance attestation feature to cryptographically verify the origin and integrity of released artifacts. This provides better security guarantees compared to distributing a pre-packaged zip file, allowing consumers to verify that artifacts were built by this workflow.

https://claude.ai/code/session_01DBohzWZhafL9mAQPtRqicJ