### PR TITLE
feat: add ribbon icon to open RSS feed reader

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { VIEW_TYPE_RHO_READER, RhoReaderPane } from "./views/RhoReaderPane";
 import { openReaderForFile } from "./views/openReaderForFile";
 import { RhoReaderSettingTab } from "./settings/RhoReaderSettingTab";
 import { registerCommands } from "./commands/register";
+import { openRssFeedReader } from "./commands/openRssFeedReader";
 import { drainPendingReads } from "./commands/utils";
 import { StatusBar } from "./statusBar";
 import {
@@ -29,6 +30,10 @@ export default class RhoReader extends Plugin {
 		);
 		this.addSettingTab(new RhoReaderSettingTab(this.app, this));
 		registerCommands(this);
+
+		this.addRibbonIcon("rss", "Open RSS feed reader", () => {
+			void openRssFeedReader(this);
+		});
 
 		this.registerEvent(
 			this.app.workspace.on("file-open", (file: TFile | null) => {


### PR DESCRIPTION
## Summary
Added a ribbon icon button to the Obsidian sidebar that allows users to quickly open the RSS feed reader.

## Changes
- Imported the `openRssFeedReader` function from the commands module
- Added a ribbon icon with the "rss" icon that triggers the RSS feed reader when clicked
- The icon is registered during plugin load in the `onload()` method

## Implementation Details
- Uses Obsidian's `addRibbonIcon()` API to create a clickable icon in the left sidebar
- The icon is labeled "Open RSS feed reader" for accessibility
- Calls `openRssFeedReader(this)` when clicked, passing the plugin instance as context

https://claude.ai/code/session_01SPp29eJ2AomNLcSdGJiv8L