### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "rho-reader",
 	"name": "Rho Reader",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"minAppVersion": "1.9.0",
 	"description": "Read and manage RSS feeds.",
 	"author": "Vishnu Bharathi",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rho-reader",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rho-reader",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rho-reader",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Read and manage RSS feeds",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
## Summary
This release updates the Rho Reader plugin to version 1.1.0 across all configuration files.

## Changes
- Updated version in `manifest.json` from 1.0.0 to 1.1.0
- Updated version in `package.json` from 1.0.0 to 1.1.0
- Fixed line ending in `manifest.json` (removed trailing newline)

## Notes
The lockfile (`package-lock.json`) was automatically updated as a result of the version change.

https://claude.ai/code/session_01SPp29eJ2AomNLcSdGJiv8L