### PR TITLE
Rebrand command and ribbon icon label to "Open Rho Reader"

### DIFF
--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -13,7 +13,7 @@ export function registerCommands(plugin: RhoReader): void {
 
 	plugin.addCommand({
 		id: "open-rss-feed-reader",
-		name: "Open RSS feed reader",
+		name: "Open Rho Reader",
 		callback: () => openRssFeedReader(plugin),
 	});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ export default class RhoReader extends Plugin {
 		this.addSettingTab(new RhoReaderSettingTab(this.app, this));
 		registerCommands(this);
 
-		this.addRibbonIcon("rss", "Open RSS feed reader", () => {
+		this.addRibbonIcon("rss", "Open Rho Reader", () => {
 			void openRssFeedReader(this);
 		});
 


### PR DESCRIPTION
## Summary
Updated user-facing labels for the RSS feed reader command and ribbon icon to use the product name "Rho Reader" instead of the generic "Open RSS feed reader" description.

## Changes
- Updated the command name in the command palette from "Open RSS feed reader" to "Open Rho Reader"
- Updated the ribbon icon tooltip/label from "Open RSS feed reader" to "Open Rho Reader"

## Details
These changes improve the user experience by using the consistent product branding ("Rho Reader") in the UI instead of a generic description. This makes the plugin more recognizable and professional in both the command palette and the ribbon interface.

https://claude.ai/code/session_01SPp29eJ2AomNLcSdGJiv8L